### PR TITLE
Store NEST id as recoil type

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The other keyword arguments are:
 | Argument | Description | Default |
 |--------------|------------------------|---|
 | `--Detector`  | Detector to be used. Has to be defined in epix.detectors | `xenonnt_detector` |
-| `--Config`  | Config file to overwrite default detector settings | in epix.detectors |
+| `--DetectorConfig`  | Config file to overwrite default detector settings | in epix.detectors |
 | `--EntryStop`  | How many entries from the ROOT file you want to process | all |
 | `--MicroSeparation`  | DBSCAN clustering distance (mm) | `0.05` |
 | `--MicroSeparationTime`  | Clustering time (ns) | `10` |

--- a/bin/run_epix
+++ b/bin/run_epix
@@ -19,7 +19,7 @@ def pars_args():
     parser.add_argument('--Detector', dest='detector', type=str,
                         action='store', default='xenonnt_detector',
                         help='Detector which should be used. Has to be defined in epix.detectors.')
-    parser.add_argument('--Config', dest='config', type=str,
+    parser.add_argument('--DetectorConfig', dest='detector_config', type=str,
                         action='store', default='',
                         help='Config file to overwrite default detector settings.')
     parser.add_argument('--EntryStop', dest='entry_stop', type=int,
@@ -224,7 +224,7 @@ def setup(args):
 
     # Init detector volume according to settings and get outer_cylinder
     # for data reduction of non-relevant interactions.
-    detector = epix.init_detector(args.detector, args.config)
+    detector = epix.init_detector(args.detector, args.detector_config)
     outer_cylinder = getattr(epix.detectors, args.detector)
     _, outer_cylinder = outer_cylinder()
     return path, file_name, detector, outer_cylinder

--- a/epix/io.py
+++ b/epix/io.py
@@ -158,7 +158,7 @@ int_dtype = [(('Waveform simulator event number.', 'event_number'), np.int32),
              (('Y position of the cluster[cm]', 'y'), np.float32),
              (('Z position of the cluster[cm]', 'z'), np.float32),
              (('Number of quanta', 'amp'), np.int32),
-             (('Recoil type of interaction.', 'recoil'), '<U5'),
+             (('Recoil type of interaction.', 'recoil'), np.int8),
              (('Energy deposit of interaction', 'e_dep'), np.float32),
              (('Eventid like in geant4 output rootfile', 'g4id'), np.int32),
              (('Volume id giving the detector subvolume', 'vol_id'), np.int32)
@@ -168,7 +168,6 @@ int_dtype = [(('Waveform simulator event number.', 'event_number'), np.int32),
 def awkward_to_wfsim_row_style(interactions):
     ninteractions = np.sum(ak.num(interactions['ed']))
     res = np.zeros(2 * ninteractions, dtype=int_dtype)
-    res['recoil'] = 'er' #default
 
     # TODO: Currently not supported rows with only electrons or photons due to
     # this super odd shape
@@ -187,8 +186,7 @@ def awkward_to_wfsim_row_style(interactions):
         else:
             res['amp'][i::2] = awkward_to_flat_numpy(interactions['photons'])
 
-        res['recoil'][i::2][awkward_to_flat_numpy(interactions['nestid'] == 0)] = 'nr'
-        res['recoil'][i::2][awkward_to_flat_numpy(interactions['nestid'] == 6)] = 'alpha'
+        res['recoil'][i::2] = awkward_to_flat_numpy(interactions['nestid'])
 
     #TODO: Add a function which generates a new event if interactions are too far apart
     return res

--- a/epix/io.py
+++ b/epix/io.py
@@ -181,12 +181,12 @@ def awkward_to_wfsim_row_style(interactions):
         res['g4id'][i::2] = awkward_to_flat_numpy(interactions['evtid'])
         res['vol_id'][i::2] = awkward_to_flat_numpy(interactions['vol_id'])
         res['e_dep'][i::2] = awkward_to_flat_numpy(interactions['ed'])
+        res['recoil'][i::2] = awkward_to_flat_numpy(interactions['nestid'])
         if i:
             res['amp'][i::2] = awkward_to_flat_numpy(interactions['electrons'])
         else:
             res['amp'][i::2] = awkward_to_flat_numpy(interactions['photons'])
 
-        res['recoil'][i::2] = awkward_to_flat_numpy(interactions['nestid'])
 
     #TODO: Add a function which generates a new event if interactions are too far apart
     return res


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**

Changes format of recoil type from string (`er`, `nr`. `alpha`) to integer pointing to the NEST id, for easier handling in the next chain stages.

@petergaemers To be merged once we also adopt the same labeling in WFsim (notice that ERs correspond to not only one id).