### PR TITLE
New Ffield format loading loading

### DIFF
--- a/epix/ElectricFieldHandler.py
+++ b/epix/ElectricFieldHandler.py
@@ -29,11 +29,7 @@ class MyElectricFieldHandler:
                              ' for the electirc field map.')
 
     def _load_field(self):
-        self.field = pd.read_csv(self.map,
-                                 comment='#',
-                                 header=None,
-                                 delim_whitespace=True,
-                                 names=['r', 'z', 'E'])
+        self.field = pd.read_csv(self.map)
 
     def _get_coordinates(self):
         self.R = np.unique(self.field['r'])


### PR DESCRIPTION
If the format of the E-Field Map is changed with https://github.com/XENONnT/private_nt_aux_files/pull/21 we need to adopt the new format in EPIX when loading the map. 