### PR TITLE
Change detector naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ bin/run_epix --InputFile <path_and_filename>
 The other keyword arguments are:
 | Argument | Description | Default |
 |--------------|------------------------|---|
-| `--Detector`  | Detector to be used. Has to be defined in epix.detectors | `xenonnt_detector` |
+| `--Detector`  | Detector to be used. Has to be defined in epix.detectors | `XENONnT` |
 | `--DetectorConfig`  | Config file to overwrite default detector settings | in epix.detectors |
 | `--EntryStop`  | How many entries from the ROOT file you want to process | all |
 | `--MicroSeparation`  | DBSCAN clustering distance (mm) | `0.05` |

--- a/bin/run_epix
+++ b/bin/run_epix
@@ -17,7 +17,7 @@ def pars_args():
                         action='store', required=True,
                         help='Input Geant4 ROOT file')
     parser.add_argument('--Detector', dest='detector', type=str,
-                        action='store', default='xenonnt_detector',
+                        action='store', default='XENONnT',
                         help='Detector which should be used. Has to be defined in epix.detectors.')
     parser.add_argument('--DetectorConfig', dest='detector_config', type=str,
                         action='store', default='',
@@ -224,7 +224,7 @@ def setup(args):
 
     # Init detector volume according to settings and get outer_cylinder
     # for data reduction of non-relevant interactions.
-    detector = epix.init_detector(args.detector, args.detector_config)
+    detector = epix.init_detector(args.detector.lower(), args.detector_config)
     outer_cylinder = getattr(epix.detectors, args.detector)
     _, outer_cylinder = outer_cylinder()
     return path, file_name, detector, outer_cylinder

--- a/bin/run_epix
+++ b/bin/run_epix
@@ -225,7 +225,7 @@ def setup(args):
     # Init detector volume according to settings and get outer_cylinder
     # for data reduction of non-relevant interactions.
     detector = epix.init_detector(args.detector.lower(), args.detector_config)
-    outer_cylinder = getattr(epix.detectors, args.detector)
+    outer_cylinder = getattr(epix.detectors, args.detector.lower())
     _, outer_cylinder = outer_cylinder()
     return path, file_name, detector, outer_cylinder
 

--- a/epix/detectors.py
+++ b/epix/detectors.py
@@ -20,7 +20,7 @@ xenon1t_z_bottom_pmts = -103.09  # cm ... top surface of the bottom PMT window
 xenon1t_z_lxe = 0.27 # cm ... liquid-gas interface
 
 
-def xenonnt_detector():
+def xenonnt():
     """
     Default XENONnT TPC with different sensitive volumes.
 
@@ -73,7 +73,7 @@ def xenonnt_detector():
     return volumes, outer_cylinder
 
 
-def xenon1t_detector():
+def xenon1t():
     """
     Default XENON1T TPC with different sensitive volumes.
 


### PR DESCRIPTION
To keep consistency with MC and WFsim naming convention.