### PR TITLE
Set recoil to 8 if classification not in [0,6,7,8,11]

### DIFF
--- a/epix/io.py
+++ b/epix/io.py
@@ -181,7 +181,10 @@ def awkward_to_wfsim_row_style(interactions):
         res['g4id'][i::2] = awkward_to_flat_numpy(interactions['evtid'])
         res['vol_id'][i::2] = awkward_to_flat_numpy(interactions['vol_id'])
         res['e_dep'][i::2] = awkward_to_flat_numpy(interactions['ed'])
-        res['recoil'][i::2] = awkward_to_flat_numpy(interactions['nestid'])
+        
+        recoil = awkward_to_flat_numpy(interactions['nestid'])
+        res['recoil'][i::2] = np.where(np.isin(recoil, [0,6,7,8,11]), recoil, 8)
+
         if i:
             res['amp'][i::2] = awkward_to_flat_numpy(interactions['electrons'])
         else:


### PR DESCRIPTION
As outlined in https://github.com/XENONnT/epix/issues/14 interactions not fitting into the classification are labeled with the NEST ID `12`.  Since WFsim only takes the cases `[0,6,7,8,11]`  and maps them to `ER`, `NR` and `ALPHA`. 

With this PR I set the recoil to `8` if it doesn't fall into the cases covered by WFsim. 

In the future we should revisit the classification and try to add more cases there so that the NEST ID `12` is strongly suppressed. The issue should stay open to remind us on this topic.  