### PR TITLE
Fix Kr83m 

### DIFF
--- a/epix/clustering.py
+++ b/epix/clustering.py
@@ -268,7 +268,7 @@ def classify(types, parenttype, creaproc, edproc):
 
     # If our data does not match any classification make it a nest None type
     # TODO: fix me
-    return 0, 0, 12
+    return np.inf, np.inf, 12
 
 
 @numba.njit

--- a/epix/clustering.py
+++ b/epix/clustering.py
@@ -241,7 +241,7 @@ classifier = np.zeros(7, dtype=[(('Interaction type', 'types'), np.dtype('<U30')
                                 (('Interaction type of the parent', 'parenttype'), np.dtype('<U30')),
                                 (('Creation process', 'creaproc'), np.dtype('<U30')),
                                 (('Energy deposit process', 'edproc'), np.dtype('<U30')),
-                                (('Atomic mass number', 'A'), np.int16),
+                                (('Atomic mass number', 'A'), np.float16),
                                 (('Atomic number', 'Z'), np.int16),
                                 (('Nest Id for qunata generation', 'nestid'), np.int16)]
                       )
@@ -249,7 +249,7 @@ classifier['types'] = ['None', 'neutron', 'alpha', 'None','None', 'gamma', 'e-']
 classifier['parenttype'] = ['None', 'None', 'None', 'Kr83[9.405]','Kr83[41.557]', 'None', 'None']
 classifier['creaproc'] = ['None', 'None', 'None', 'None', 'None','None', 'None']
 classifier['edproc'] = ['ionIoni', 'hadElastic', 'None', 'None','None', 'None', 'None']
-classifier['A'] = [0, 0, 4, 0, 0, 0, 0]
+classifier['A'] = [np.inf, np.inf, 4, np.inf, np.inf, np.inf, np.inf]
 classifier['Z'] = [0, 0, 2, 0, 0, 0, 0]
 classifier['nestid'] = [0, 0, 6, 11, 11, 7, 8]
 

--- a/epix/clustering.py
+++ b/epix/clustering.py
@@ -249,7 +249,8 @@ classifier['types'] = ['None', 'neutron', 'alpha', 'None','None', 'gamma', 'e-']
 classifier['parenttype'] = ['None', 'None', 'None', 'Kr83[9.405]','Kr83[41.557]', 'None', 'None']
 classifier['creaproc'] = ['None', 'None', 'None', 'None', 'None','None', 'None']
 classifier['edproc'] = ['ionIoni', 'hadElastic', 'None', 'None','None', 'None', 'None']
-classifier['A'] = [np.iinfo(np.int16).max, np.iinfo(np.int16).max, 4, np.iinfo(np.int16).max, np.iinfo(np.int16).max, np.iinfo(np.int16).max, np.iinfo(np.int16).max]
+classifier['A'] = [np.iinfo(np.int16).max, np.iinfo(np.int16).max, 4, np.iinfo(np.int16).max,\
+    np.iinfo(np.int16).max, np.iinfo(np.int16).max, np.iinfo(np.int16).max]
 classifier['Z'] = [0, 0, 2, 0, 0, 0, 0]
 classifier['nestid'] = [0, 0, 6, 11, 11, 7, 8]
 

--- a/epix/clustering.py
+++ b/epix/clustering.py
@@ -237,6 +237,8 @@ def _cluster(x, y, z, ed, time, ci,
         res.end_list()
 
 
+infinity = np.iinfo(np.int16).max
+
 classifier = np.zeros(7, dtype=[(('Interaction type', 'types'), np.dtype('<U30')),
                                 (('Interaction type of the parent', 'parenttype'), np.dtype('<U30')),
                                 (('Creation process', 'creaproc'), np.dtype('<U30')),
@@ -249,8 +251,7 @@ classifier['types'] = ['None', 'neutron', 'alpha', 'None','None', 'gamma', 'e-']
 classifier['parenttype'] = ['None', 'None', 'None', 'Kr83[9.405]','Kr83[41.557]', 'None', 'None']
 classifier['creaproc'] = ['None', 'None', 'None', 'None', 'None','None', 'None']
 classifier['edproc'] = ['ionIoni', 'hadElastic', 'None', 'None','None', 'None', 'None']
-classifier['A'] = [np.iinfo(np.int16).max, np.iinfo(np.int16).max, 4, np.iinfo(np.int16).max,\
-    np.iinfo(np.int16).max, np.iinfo(np.int16).max, np.iinfo(np.int16).max]
+classifier['A'] = [infinity, infinity, 4, infinity,infinity, infinity, infinity]
 classifier['Z'] = [0, 0, 2, 0, 0, 0, 0]
 classifier['nestid'] = [0, 0, 6, 11, 11, 7, 8]
 
@@ -269,7 +270,7 @@ def classify(types, parenttype, creaproc, edproc):
 
     # If our data does not match any classification make it a nest None type
     # TODO: fix me
-    return np.iinfo(np.int16).max, np.iinfo(np.int16).max, 12
+    return infinity, infinity, 12
 
 
 @numba.njit

--- a/epix/clustering.py
+++ b/epix/clustering.py
@@ -241,7 +241,7 @@ classifier = np.zeros(7, dtype=[(('Interaction type', 'types'), np.dtype('<U30')
                                 (('Interaction type of the parent', 'parenttype'), np.dtype('<U30')),
                                 (('Creation process', 'creaproc'), np.dtype('<U30')),
                                 (('Energy deposit process', 'edproc'), np.dtype('<U30')),
-                                (('Atomic mass number', 'A'), np.float16),
+                                (('Atomic mass number', 'A'), np.int16),
                                 (('Atomic number', 'Z'), np.int16),
                                 (('Nest Id for qunata generation', 'nestid'), np.int16)]
                       )
@@ -249,7 +249,7 @@ classifier['types'] = ['None', 'neutron', 'alpha', 'None','None', 'gamma', 'e-']
 classifier['parenttype'] = ['None', 'None', 'None', 'Kr83[9.405]','Kr83[41.557]', 'None', 'None']
 classifier['creaproc'] = ['None', 'None', 'None', 'None', 'None','None', 'None']
 classifier['edproc'] = ['ionIoni', 'hadElastic', 'None', 'None','None', 'None', 'None']
-classifier['A'] = [np.inf, np.inf, 4, np.inf, np.inf, np.inf, np.inf]
+classifier['A'] = [np.iinfo(np.int16).max, np.iinfo(np.int16).max, 4, np.iinfo(np.int16).max, np.iinfo(np.int16).max, np.iinfo(np.int16).max, np.iinfo(np.int16).max]
 classifier['Z'] = [0, 0, 2, 0, 0, 0, 0]
 classifier['nestid'] = [0, 0, 6, 11, 11, 7, 8]
 
@@ -268,7 +268,7 @@ def classify(types, parenttype, creaproc, edproc):
 
     # If our data does not match any classification make it a nest None type
     # TODO: fix me
-    return np.inf, np.inf, 12
+    return np.iinfo(np.int16).max, np.iinfo(np.int16).max, 12
 
 
 @numba.njit

--- a/epix/quanta_generation.py
+++ b/epix/quanta_generation.py
@@ -32,19 +32,6 @@ def quanta_from_NEST(en, model, e_field, A, Z, create_s2, **kwargs):
     nc = nestpy.NESTcalc(nestpy.VDetector())
     density = 2.862  # g/cm^3
 
-    # Fix for Kr83m events.
-    # Energies have to be exactly 32.1 keV or 9.1 keV
-    # See: https://github.com/NESTCollaboration/nest/blob/master/src/NEST.cpp#L567
-    # and: https://github.com/NESTCollaboration/nest/blob/master/src/NEST.cpp#L585
-    # TODO: There must be something odd with our clustering, that we need
-    #  this?
-    max_allowed_energy_difference = 1  # keV
-    if model == 11:
-        if abs(en - 32.1) > max_allowed_energy_difference:
-            en = 32.1
-        if abs(en - 9.1) > max_allowed_energy_difference:
-            en = 9.1
-
     # Some addition taken from
     # https://github.com/NESTCollaboration/nestpy/blob/e82c71f864d7362fee87989ed642cd875845ae3e/src/nestpy/helpers.py#L94-L100
     if model == 0 and en > 2e2:

--- a/epix/quanta_generation.py
+++ b/epix/quanta_generation.py
@@ -32,6 +32,17 @@ def quanta_from_NEST(en, model, e_field, A, Z, create_s2, **kwargs):
     nc = nestpy.NESTcalc(nestpy.VDetector())
     density = 2.862  # g/cm^3
 
+    # Fix for Kr83m events.
+    # Energies have to be very close to 32.1 keV or 9.4 keV
+    # See: https://github.com/NESTCollaboration/nest/blob/master/src/NEST.cpp#L567
+    # and: https://github.com/NESTCollaboration/nest/blob/master/src/NEST.cpp#L585
+    max_allowed_energy_difference = 1  # keV
+    if model == 11:
+        if abs(en - 32.1) > max_allowed_energy_difference:
+            en = 32.1
+        if abs(en - 9.4) > max_allowed_energy_difference:
+            en = 9.4
+
     # Some addition taken from
     # https://github.com/NESTCollaboration/nestpy/blob/e82c71f864d7362fee87989ed642cd875845ae3e/src/nestpy/helpers.py#L94-L100
     if model == 0 and en > 2e2:


### PR DESCRIPTION
With this PR I try to fix the Kr83m related issues described in https://github.com/XENONnT/epix/issues/29 and https://github.com/XENONnT/epix/issues/17. 

NEST does not longer require the exact energies for Kr83m (https://github.com/NESTCollaboration/nest/blob/master/src/NEST.cpp#L570) since PR:https://github.com/NESTCollaboration/nest/pull/88. The modification of Kr83m energies in epix was removed for that reason. 

To fix the issue https://github.com/XENONnT/epix/issues/29 the default value for A was set to the maximal int16 value instead of 0.