### PR TITLE
Added local field and number of excitons for S1 time generation

### DIFF
--- a/epix/io.py
+++ b/epix/io.py
@@ -227,7 +227,9 @@ def awkward_to_wfsim_row_style(interactions):
         res['g4id'][i::2] = awkward_to_flat_numpy(interactions['evtid'])
         res['vol_id'][i::2] = awkward_to_flat_numpy(interactions['vol_id'])
         res['e_dep'][i::2] = awkward_to_flat_numpy(interactions['ed'])
-        
+        if 'local_field' in res.dtype.names:
+            res['local_field'][i::2] = awkward_to_flat_numpy(interactions['e_field'])
+
         recoil = awkward_to_flat_numpy(interactions['nestid'])
         res['recoil'][i::2] = np.where(np.isin(recoil, [0,6,7,8,11]), recoil, 8)
 
@@ -235,7 +237,8 @@ def awkward_to_wfsim_row_style(interactions):
             res['amp'][i::2] = awkward_to_flat_numpy(interactions['electrons'])
         else:
             res['amp'][i::2] = awkward_to_flat_numpy(interactions['photons'])
-
+            if 'n_excitons' in res.dtype.names:
+                res['n_excitons'][i::2] = awkward_to_flat_numpy(interactions['excitons'])
     # Remove entries with no quanta
     res = res[res['amp'] > 0]
     return res

--- a/epix/quanta_generation.py
+++ b/epix/quanta_generation.py
@@ -67,8 +67,10 @@ def quanta_from_NEST(en, model, e_field, A, Z, create_s2, **kwargs):
 
     photons = event_quanta.photons
 
+    excitons = event_quanta.excitons
+
     electrons = 0
     if create_s2:
         electrons = event_quanta.electrons
 
-    return photons, electrons
+    return photons, electrons, excitons

--- a/epix/run_epix.py
+++ b/epix/run_epix.py
@@ -112,15 +112,17 @@ def main(args, return_df=False, return_wfsim_instructions=False, strax=False):
     if args['debug']:
         print('Generating photons and electrons for events')
     # Generate quanta:
-    photons, electrons = epix.quanta_from_NEST(epix.awkward_to_flat_numpy(result['ed']),
-                                               epix.awkward_to_flat_numpy(result['nestid']),
-                                               epix.awkward_to_flat_numpy(result['e_field']),
-                                               epix.awkward_to_flat_numpy(result['A']),
-                                               epix.awkward_to_flat_numpy(result['Z']),
-                                               epix.awkward_to_flat_numpy(result['create_S2']),
-                                               density=epix.awkward_to_flat_numpy(result['xe_density']))
+    photons, electrons, excitons = epix.quanta_from_NEST(epix.awkward_to_flat_numpy(result['ed']),
+                                                         epix.awkward_to_flat_numpy(result['nestid']),
+                                                         epix.awkward_to_flat_numpy(result['e_field']),
+                                                         epix.awkward_to_flat_numpy(result['A']),
+                                                         epix.awkward_to_flat_numpy(result['Z']),
+                                                         epix.awkward_to_flat_numpy(result['create_S2']),
+                                                         density=epix.awkward_to_flat_numpy(result['xe_density']))
     result['photons'] = epix.reshape_awkward(photons, ak.num(result['ed']))
     result['electrons'] = epix.reshape_awkward(electrons, ak.num(result['ed']))
+    result['excitons'] = epix.reshape_awkward(excitons, ak.num(result['ed']))
+
     if args['debug']:
         _ = monitor_time(tnow, 'get quanta.')
 


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**
This PR adds a possibility to store local field and number of excitons to instructions. This information is needed for usage of S1 pulse shape coming from NEST and Geant4 timing splines. 
