### PR TITLE
Add return for removed excitons (#34 bugfix)

### DIFF
--- a/epix/quanta_generation.py
+++ b/epix/quanta_generation.py
@@ -28,6 +28,7 @@ def quanta_from_NEST(en, model, e_field, A, Z, create_s2, **kwargs):
     Returns:
         photons (numpy.array): Number of generated photons
         electrons (numpy.array): Number of generated electrons
+        excitons (numpy.array): Number of generated excitons
     """
     nc = nestpy.NESTcalc(nestpy.VDetector())
     density = 2.862  # g/cm^3
@@ -47,13 +48,13 @@ def quanta_from_NEST(en, model, e_field, A, Z, create_s2, **kwargs):
     # https://github.com/NESTCollaboration/nestpy/blob/e82c71f864d7362fee87989ed642cd875845ae3e/src/nestpy/helpers.py#L94-L100
     if model == 0 and en > 2e2:
         warnings.warn(f"Energy deposition of {en} keV beyond NEST validity for NR model of 200 keV - Remove Interaction")
-        return -1, -1
+        return -1, -1, -1
     if model == 7 and en > 3e3:
         warnings.warn(f"Energy deposition of {en} keV beyond NEST validity for gamma model of 3 MeV - Remove Interaction")
-        return -1, -1
+        return -1, -1, -1
     if model == 8 and en > 3e3:
         warnings.warn(f"Energy deposition of {en} keV beyond NEST validity for beta model of 3 MeV - Remove Interaction")
-        return -1, -1
+        return -1, -1, -1
 
     y = nc.GetYields(interaction=nestpy.INTERACTION_TYPE(model),
                      energy=en,
@@ -66,9 +67,7 @@ def quanta_from_NEST(en, model, e_field, A, Z, create_s2, **kwargs):
     event_quanta = nc.GetQuanta(y)  # Density argument is not use in function...
 
     photons = event_quanta.photons
-
     excitons = event_quanta.excitons
-
     electrons = 0
     if create_s2:
         electrons = event_quanta.electrons


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**
Solving https://github.com/XENONnT/epix/issues/37
This issue arose from the cases in which we remove the interaction because its energy is beyond the NEST limits. The return statement for excitons was missing.

Some additional comments (for @terliuk):
- I still feel we do not advantage much from the if statements, for the efield and excitons export. This will always be true from now on.
- Is this indent correct? https://github.com/XENONnT/epix/blob/d256673e3e0bca86dac185c290c6df100d26e8b1/epix/io.py#L240-L241 I do not remember if we had discussed it, sorry.