### PR TITLE
Tuning clustering defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ The other keyword arguments are:
 | `--CutOnEventid`  | If selected, the next two arguments act on the G4 event id, and not the entry number (default) | `false` |
 | `--EntryStart`  | First event to be read | 0 |
 | `--EntryStop`  | How many entries from the ROOT file you want to process | all |
-| `--MicroSeparation`  | DBSCAN clustering distance (mm) | `0.05` |
+| `--MicroSeparation`  | DBSCAN clustering distance (mm) | `0.005` |
 | `--MicroSeparationTime`  | Clustering time (ns) | `10` |
-| `--TagClusterBy`  | decide if you tag the cluster (particle type, energy depositing process) according to first interaction in it (`time`) or most energetic (`energy`) | `time` |
+| `--TagClusterBy`  | decide if you tag the cluster (particle type, energy depositing process) according to first interaction in it (`time`) or most energetic (`energy`) | `energy` |
 | `--MaxDelay`  | Time after which we cut the rest of the event (ns) | `1e7` |
 | `--SourceRate`  | Event rate for event separation<br /> - `0` for no time shift (G4 time remains)<br /> - `-1` for clean time shift between events<br /> - `>0` (Hz) for random spacing | `0` |
 | `--JobNumber`  | Job number in full chain simulation. Offset is computed as `JobNumber * n_simulated_events/SourceRate`, where `n_simulated_events` is read from file. | `0` |

--- a/bin/run_epix
+++ b/bin/run_epix
@@ -26,13 +26,13 @@ def pars_args():
                         action='store',
                         help='Number of entries to read from first. Defaulted to all.')
     parser.add_argument('--MicroSeparation', dest='micro_separation', type=float,
-                        action='store', default=0.05,
+                        action='store', default=0.005,
                         help='Spatial resolution for DBSCAN micro-clustering [mm].')
     parser.add_argument('--MicroSeparationTime', dest='micro_separation_time', type=float,
                         action='store', default=10,
                         help='Time resolution for DBSCAN micro-clustering [ns].')
     parser.add_argument('--TagClusterBy', dest='tag_cluster_by', type=str,
-                        action='store', default='time',
+                        action='store', default='energy',
                         help=('Classification of the type of particle of a cluster, '
                               'based on most energetic contributor ("energy") or first '
                               'depositing particle ("time").'),


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**

Changing the defaults for clustering distance and cluster tagging. This is based on the recent discussions on neutron modeling and [this thread](https://xenonnt.slack.com/archives/C0177G05M1P/p1626335851341300) in particular.

We can also leave the current defaults. This change is not so pressing/relevant, plus probably many others will follow. I was just thinking about this small modification before the next release. Let me know your thoughts.