### PR TITLE
Alternative treatment for empty input

### DIFF
--- a/epix/clustering.py
+++ b/epix/clustering.py
@@ -26,12 +26,12 @@ def find_cluster(interactions, cluster_size_space, cluster_size_time):
         df.append(ak.to_pandas(interactions[key], anonymous=key))
     df = pd.concat(df, axis=1)
 
+    if df.empty:
+        # TPC interaction is empty
+        return interactions
+
     # Splitting into individual events and apply time clustering:
     groups = df.groupby('entry')
-    if len(groups.count()) == 0:
-        # TPC interaction is empty
-        #interactions = []
-        return  interactions
 
     df["time_cluster"] = np.concatenate(groups.apply(lambda x: simple_1d_clustering(x.t.values, cluster_size_time)))
 

--- a/epix/clustering.py
+++ b/epix/clustering.py
@@ -28,6 +28,11 @@ def find_cluster(interactions, cluster_size_space, cluster_size_time):
 
     # Splitting into individual events and apply time clustering:
     groups = df.groupby('entry')
+    if len(groups.count()) == 0:
+        # TPC interaction is empty
+        #interactions = []
+        return  interactions
+
     df["time_cluster"] = np.concatenate(groups.apply(lambda x: simple_1d_clustering(x.t.values, cluster_size_time)))
 
     # Splitting into individual events and time cluster and apply space clustering space:
@@ -39,7 +44,6 @@ def find_cluster(interactions, cluster_size_space, cluster_size_time):
         for j in range(len(groups[i])):
             groups[i][j]+=add_to_cluster
             add_to_cluster = np.max(groups[i][j])+1
-
     df['cluster_id'] = np.concatenate(groups.values)
 
     ci = df.loc[:, 'cluster_id'].values

--- a/epix/common.py
+++ b/epix/common.py
@@ -35,6 +35,8 @@ def _reshape_awkward(array, offsets, res):
 
 
 def awkward_to_flat_numpy(array):
+    if len(array) <= 0:
+        return np.array([])
     return (ak.to_numpy(ak.flatten(array)))
 
 
@@ -65,3 +67,40 @@ def offset_range(offsets):
         res[i:i+o] = ind
         i += o
     return res
+
+
+def ak_num(array, **kwargs):
+    """
+    awkward.num() wrapper also for work in empty array
+    :param array: Data containing nested lists to count.
+    :param kwargs: keywords arguments for awkward.num().
+    :return: an array of integers specifying the number of elements
+        at a particular level. If array is empty, return empty.
+    """
+    if len(array) <= 0:
+        return ak.from_numpy(np.array([], dtype='int64'))
+    return ak.num(array, **kwargs)
+
+def calc_dt(result):
+    """
+    Calculate dt, the time difference from the initial data in the event
+    With empty check
+    :param result: Including `t` field
+    :return dt: Array like
+    """
+    if len(result) <= 0:  # Empty
+        return np.array([])
+    dt = result['t'] - result['t'][:, 0]  # if result is empty, Error
+    return dt
+
+
+def apply_time_offset(result, dt):
+    """
+    Apply time offset with empty check
+    :param result: np.structured_array
+    :param dt: Array timing offset for each events
+    :return: result with timing offsets for each events
+    """
+    if len(result) <= 0:
+        return result
+    return result['t'][:, :] + dt

--- a/epix/detector_volumes.py
+++ b/epix/detector_volumes.py
@@ -145,11 +145,14 @@ def in_cylinder(x, y, z, min_z, max_z, max_r):
         max_z: Exclusive upper z boundary
         max_r: Exclusive radial boundary
     """
-    r = np.sqrt(x**2 + y**2)
+    r = np.sqrt(x ** 2 + y ** 2)
     m = r < max_r
     m = m & (z < max_z)
     m = m & (z >= min_z)
     return m
+
+
+res_det_dtype = [('xe_density', 'float64'), ('vol_id', 'int64'), ('create_S2', 'bool')]
 
 
 def in_sensitive_volume(events, sensitive_volumes):
@@ -167,6 +170,8 @@ def in_sensitive_volume(events, sensitive_volumes):
     Returns:
         ak.array: Awkward array containing the event ids.
     """
+    if len(events) <= 0:  # Input empty
+        return ak.from_numpy(np.array([], dtype=res_det_dtype))
     for ind, vol in enumerate(sensitive_volumes):
         res = ak.ArrayBuilder()
         res = _inside_sens_vol(events['x'],

--- a/epix/io.py
+++ b/epix/io.py
@@ -212,6 +212,9 @@ def awkward_to_wfsim_row_style(interactions):
     :return: Structured numpy.array. Each row represents either a S1 or
         S2
     """
+    if len(interactions) <= 0:
+        return np.array([], dtype=int_dtype)
+
     ninteractions = np.sum(ak.num(interactions['ed']))
     res = np.zeros(2 * ninteractions, dtype=int_dtype)
 
@@ -242,3 +245,4 @@ def awkward_to_wfsim_row_style(interactions):
     # Remove entries with no quanta
     res = res[res['amp'] > 0]
     return res
+

--- a/epix/run_epix.py
+++ b/epix/run_epix.py
@@ -5,6 +5,7 @@ import numpy as np
 import pandas as pd
 import warnings
 
+import wfsim
 import epix
 
 
@@ -35,6 +36,8 @@ def main(args, return_df=False, return_wfsim_instructions=False, strax=False):
 
     # Cluster finding and clustering (convert micro_separation mm -> cm):
     inter = epix.find_cluster(inter, args['micro_separation']/10, args['micro_separation_time'])
+    if len(inter) == 0 and return_wfsim_instructions:
+        return np.array([], dtype=wfsim.instruction_dtype) # empty
 
     if args['debug']:
         tnow = monitor_time(tnow, 'find clusters.')

--- a/epix/run_epix.py
+++ b/epix/run_epix.py
@@ -36,8 +36,9 @@ def main(args, return_df=False, return_wfsim_instructions=False, strax=False):
 
     # Cluster finding and clustering (convert micro_separation mm -> cm):
     inter = epix.find_cluster(inter, args['micro_separation']/10, args['micro_separation_time'])
-    if len(inter) == 0 and return_wfsim_instructions:
-        return np.array([], dtype=wfsim.instruction_dtype) # empty
+
+    if len(inter) == 0:  # Earlier return if TPC interactions are empty.
+        return np.array([], dtype=wfsim.instruction_dtype)  # empty
 
     if args['debug']:
         tnow = monitor_time(tnow, 'find clusters.')

--- a/epix/run_epix.py
+++ b/epix/run_epix.py
@@ -8,6 +8,7 @@ import warnings
 import wfsim
 import epix
 
+from .common import ak_num, calc_dt, apply_time_offset
 
 def main(args, return_df=False, return_wfsim_instructions=False, strax=False):
     """Call this function from the run_epix script"""
@@ -37,8 +38,8 @@ def main(args, return_df=False, return_wfsim_instructions=False, strax=False):
     # Cluster finding and clustering (convert micro_separation mm -> cm):
     inter = epix.find_cluster(inter, args['micro_separation']/10, args['micro_separation_time'])
 
-    if len(inter) == 0:  # Earlier return if TPC interactions are empty.
-        return np.array([], dtype=wfsim.instruction_dtype)  # empty
+#    if len(inter) == 0:  # Earlier return if TPC interactions are empty.
+#        return np.array([], dtype=wfsim.instruction_dtype)  # empty
 
     if args['debug']:
         tnow = monitor_time(tnow, 'find clusters.')
@@ -54,7 +55,7 @@ def main(args, return_df=False, return_wfsim_instructions=False, strax=False):
     # Sort detector volumes and keep interactions in selected ones:
     if args['debug']:
         print('Removing clusters not in volumes:', *[v.name for v in args['detector_config']])
-        print(f'Number of clusters before: {np.sum(ak.num(result["ed"]))}')
+        print(f'Number of clusters before: {np.sum(ak_num(result["ed"]))}')
 
     # Returns all interactions which are inside in one of the volumes,
     # Checks for volume overlap, assigns Xe density and create_S2 to
@@ -69,29 +70,15 @@ def main(args, return_df=False, return_wfsim_instructions=False, strax=False):
     result = result[m]
 
     # Removing now empty events as a result of the selection above:
-    m = ak.num(result['ed']) > 0
+    m = ak_num(result['ed']) > 0
     result = result[m]
 
     if args['debug']:
-        print(f'Number of clusters after: {np.sum(ak.num(result["ed"]))}')
+        print(f'Number of clusters after: {np.sum(ak_num(result["ed"]))}')
         print('Assigning electric field to clusters')
 
-    if not ak.any(m):
-        # There are not any events left so return empty array:
-        #TODO: Add option for WFSim
-        warnings.warn('No interactions left, return empty DataFrame.')
-        if return_df:
-            if args.output_path and not os.path.isdir(args.output_path):
-                os.makedirs(args.output_path)
-
-            output_path_and_name = os.path.join(args.output_path,
-                                                args['file_name'][:-5] + "_wfsim_instructions.csv")
-            df = pd.DataFrame()
-            df.to_csv(output_path_and_name, index=False)
-            return
-
     # Add electric field to array:
-    efields = np.zeros(np.sum(ak.num(result)), np.float32)
+    efields = np.zeros(np.sum(ak_num(result)), np.float32)
     # Loop over volume and assign values:
     for volume in args['detector_config']:
         if isinstance(volume.electric_field, (float, int)):
@@ -104,28 +91,31 @@ def main(args, return_df=False, return_wfsim_instructions=False, strax=False):
                                             epix.awkward_to_flat_numpy(result.z)
                                             )
 
-    result['e_field'] = epix.reshape_awkward(efields, ak.num(result))
+    result['e_field'] = epix.reshape_awkward(efields, ak_num(result))
 
     # Sort entries (in an event) by in time, then chop all delayed
     # events which are too far away from the rest.
     # (This is a requirement of WFSim)
     result = result[ak.argsort(result['t'])]
-    dt = result['t'] - result['t'][:, 0]
+    dt = calc_dt(result)
     result = result[dt <= args['max_delay']]
 
     if args['debug']:
         print('Generating photons and electrons for events')
     # Generate quanta:
-    photons, electrons, excitons = epix.quanta_from_NEST(epix.awkward_to_flat_numpy(result['ed']),
-                                                         epix.awkward_to_flat_numpy(result['nestid']),
-                                                         epix.awkward_to_flat_numpy(result['e_field']),
-                                                         epix.awkward_to_flat_numpy(result['A']),
-                                                         epix.awkward_to_flat_numpy(result['Z']),
-                                                         epix.awkward_to_flat_numpy(result['create_S2']),
-                                                         density=epix.awkward_to_flat_numpy(result['xe_density']))
-    result['photons'] = epix.reshape_awkward(photons, ak.num(result['ed']))
-    result['electrons'] = epix.reshape_awkward(electrons, ak.num(result['ed']))
-    result['excitons'] = epix.reshape_awkward(excitons, ak.num(result['ed']))
+    if len(result) > 0:
+        photons, electrons, excitons = epix.quanta_from_NEST(epix.awkward_to_flat_numpy(result['ed']),
+                                                             epix.awkward_to_flat_numpy(result['nestid']),
+                                                             epix.awkward_to_flat_numpy(result['e_field']),
+                                                             epix.awkward_to_flat_numpy(result['A']),
+                                                             epix.awkward_to_flat_numpy(result['Z']),
+                                                             epix.awkward_to_flat_numpy(result['create_S2']),
+                                                             density=epix.awkward_to_flat_numpy(result['xe_density']))
+        result['photons'] = epix.reshape_awkward(photons, ak_num(result['ed']))
+        result['electrons'] = epix.reshape_awkward(electrons, ak_num(result['ed']))
+        result['excitons'] = epix.reshape_awkward(excitons, ak_num(result['ed']))
+    else:  # Empty case: `epix.quanta_from_NEST()` is a vectorized function, thus escape like that
+        result['photons'], result['electrons'], result['excitons'] = np.array([]), np.array([]), np.array([])
 
     if args['debug']:
         _ = monitor_time(tnow, 'get quanta.')
@@ -134,7 +124,7 @@ def main(args, return_df=False, return_wfsim_instructions=False, strax=False):
     number_of_events = len(result["t"])
     if args['source_rate'] == -1:
         # Only needed for a clean separation:
-        result['t'] = result['t'] - result['t'][:, 0]
+        result['t'] = calc_dt(result)
 
         dt = epix.times_for_clean_separation(number_of_events, args['max_delay'])
         if args['debug']:
@@ -154,9 +144,11 @@ def main(args, return_df=False, return_wfsim_instructions=False, strax=False):
         if args['debug']:
             print(f"Fixed event rate of {args['source_rate']} Hz")
 
-    result['t'] = result['t'][:, :] + dt
+    result['t'] = apply_time_offset(result, dt)
 
     # Reshape instructions:
+    if args['debug'] & (len(result) <= 0):
+        warnings.warn('No interactions left, return empty DataFrame.')
     instructions = epix.awkward_to_wfsim_row_style(result)
     if args['source_rate'] != 0:
         # Only sort by time again if source rates were applied, otherwise

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ uproot >= 4.0.0
 awkward >= 1.0.0
 numba
 sklearn
+wfsim


### PR DESCRIPTION
**What is the problem / what does the code in this PR do**
Alternative solution for #36 following @ramirezdiego and @WenzDaniel 's comments.
Following their comments, I added empty check in the almost all functions.
In this treatment, these function works as transparent for empty input.
I've tested them on my local environment, and it passed.
I still don't agree that this treatments contributes readability and reducing complexity. However, I would like to run nVeto WFSim as soon as possible, please let me know the fastest way.

**Can you give a minimal working example (or illustrate with a figure)?**
I've test `run_epix` script with the following file and options.
##### File on dali
 - `/home/mzks/run_laser_1photon_100.root` -> File which includes only nVeto hits (optical simulation data)
 - `/dali/lgrandi/xenonnt/simulations/testing_epix_wfsim/tpc_and_nveto_cryoneutrons_200.root`

##### Options
- `--SourceRate` -1, 0, 100
- `return_df`=True / False
- `return_wfsim_instructions` = True / False
