### PR TITLE
Fix for interaction classification parameters which are passed to NEST.

### DIFF
--- a/epix/clustering.py
+++ b/epix/clustering.py
@@ -251,11 +251,8 @@ classifier['types'] = ['None', 'neutron', 'alpha', 'None','None', 'gamma', 'e-']
 classifier['parenttype'] = ['None', 'None', 'None', 'Kr83[9.405]','Kr83[41.557]', 'None', 'None']
 classifier['creaproc'] = ['None', 'None', 'None', 'None', 'None','None', 'None']
 classifier['edproc'] = ['ionIoni', 'hadElastic', 'None', 'None','None', 'None', 'None']
-
-Xe_A = 131.293
-Xe_Z = 54.0
-classifier['A'] = [Xe_A, Xe_A, 4, infinity, infinity, infinity, infinity]
-classifier['Z'] = [Xe_Z, Xe_Z, 2, 0, 0, 0, 0]
+classifier['A'] = [0, 0, 4, infinity, infinity, 0, 0]
+classifier['Z'] = [0, 0, 2, 0, 0, 0, 0]
 classifier['nestid'] = [0, 0, 6, 11, 11, 7, 8]
 
 


### PR DESCRIPTION
This PR fixes the issue reported here:

[#43](`https://github.com/XENONnT/epix/issues/43`
)

There's one thing which needs to be clarified - what is the proper parameter to pass in case of Kr83m:

[NEST.cpp#L830-L831](https://github.com/NESTCollaboration/nest/blob/1689250f8f4a6394fa2ac530fb8ade733057253b/src/NEST.cpp#L830-L831)

The mass number we pass to this function actually serves as **maxTimeSeparation** which is passed to 

[NEST.cpp#L618](https://github.com/NESTCollaboration/nest/blob/1689250f8f4a6394fa2ac530fb8ade733057253b/src/NEST.cpp#L618)

We pass 'infinity' here, which makes sense. However, please look at these NEST lines to double-check it.