### PR TITLE
Remove strong dependency of a TParameter nEVENTS

### DIFF
--- a/epix/io.py
+++ b/epix/io.py
@@ -262,10 +262,17 @@ class file_loader():
         # Searching for TTree according to old/new MC file structure:
         if root_dir.classname_of('events') == 'TTree':
             ttree = root_dir['events']
-            n_simulated_events = root_dir['nEVENTS'].members['fVal']
+            # Check existance of TParameter 'nEVENTS'
+            if [True for root_ls in root_dir.items() if root_ls[0].find('nEVENTS') >= 0]:
+                n_simulated_events = root_dir['nEVENTS'].members['fVal']
+            else:
+                n_simulated_events = ttree['eventid'].array(library='np').max()
         elif root_dir.classname_of('events/events') == 'TTree':
             ttree = root_dir['events/events']
-            n_simulated_events = root_dir['events/nbevents'].members['fVal']
+            if [True for root_ls in root_dir['events'].items() if root_ls[0].find('nbevents') >= 0]:
+                n_simulated_events = root_dir['events/nbevents'].members['fVal']
+            else:
+                n_simulated_events = ttree['eventid'].array(library='np').max()
         else:
             ttrees = []
             for k, v in root_dir.classnames().items():


### PR DESCRIPTION
What is the problem / what does the code in this PR do

the n_simulated_event are actually not required by the process.
I want to remove the strong dependence for nEVENTS in EPIX, not to remove the parameter from official Geant4 output.

Specifically, I'm woriking to evaluate nVeto tagging efficiency. Many events are garbage, thus I would like to add a very loose cut to drop events then merge these ROOT file before running WFSim.
ROOT is good at merging the same types of TTree, but not parameter. I understand the official xenon-mc output is a first-class citizen, but it is better to have a room for wild ROOT file.

In this PR, if there is nEVENTS, nothing will be changed, it will use `nEVENTS` as usual.
But if not, it will use the maximum of eventid as n_simulated_events.
