### PR TITLE
Fix epix to allow version bump

### DIFF
--- a/epix/clustering.py
+++ b/epix/clustering.py
@@ -106,7 +106,7 @@ def find_cluster(interactions, cluster_size_space, cluster_size_time):
     # TODO is there a better way to get the df?
     df = []
     for key in ['x', 'y', 'z', 'ed', 't']:
-        df.append(ak.to_pandas(interactions[key], anonymous=key))
+        df.append(ak.to_dataframe(interactions[key], anonymous=key))
     df = pd.concat(df, axis=1)
 
     if df.empty:

--- a/epix/detector_volumes.py
+++ b/epix/detector_volumes.py
@@ -183,20 +183,21 @@ def in_sensitive_volume(events, sensitive_volumes):
                                vol.volume_id,
                                vol.xe_density,
                                vol.create_S2,
-                               res)
+                               res)  
         if ind:
+            new_results = res.snapshot() # Convert ArrayBuilder into true ak.Array
             # Now we add the other results, but first test if 
             # volumes overlap. Only possible if we explicitly loop
             # over everything. This reduces performance but adds layer of
             # safety.
-            m = (result['vol_id'] > 0) & (res['vol_id'] == vol.volume_id)
+            m = (result['vol_id'] > 0) & (new_results['vol_id'] == vol.volume_id)
             if ak.any(m):
                 overlapping_id = result[m][0]
                 # Get volume name:
                 name = [vol.name for vol in sensitive_volumes if vol.volume_id == overlapping_id][0]
                 raise ValueError(f'The volume {vol.name} is overlapping with'
                                  f' volume {name}!')
-            new_results = res.snapshot()
+            
             for field in result.fields:
                 # Workaround since we cannot sum up records-arrays anymore
                 result[field] = result[field] + new_results[field]


### PR DESCRIPTION
Small fixes to allow version bump awkward, numpy, numba and uproot. Tested default processing with the following file:

```
path = "/project2/lgrandi/xenonnt/simulations/testing"
file_name = "pmt_neutrons_100.root"
```

Versions used for the test:

```
EPIX: 0.3.5
NUMBA; 0.57.1
AWKWARD: 2.5.1 
UPROOT: 5.2.1
NUMPY: 1.22.4
```