### PR TITLE
Fix cut_by_eventid again

### DIFF
--- a/epix/io.py
+++ b/epix/io.py
@@ -185,20 +185,17 @@ class file_loader():
 
         # If user specified entry start/stop we have to update number of
         # events for source rate computation:
-        if self.kwargs['entry_start'] is not None:
+        if self.kwargs['entry_start'] is not None and self.cut_by_eventid:
             start = self.kwargs['entry_start']
         else:
             start = 0
-        if self.kwargs['entry_stop'] is not None:
+        if self.kwargs['entry_stop'] is not None and self.cut_by_eventid:
             stop = self.kwargs['entry_stop']
         else:
             stop = n_simulated_events
 
-        if self.cut_by_eventid:
-            # Start/stop refers to eventid so drop start drop from kwargs
-            # dict if specified, otherwise we cut again on rows.
-            self.kwargs.pop('entry_start', None)
-            self.kwargs.pop('entry_stop', None)
+        self.kwargs.pop('entry_start', None)
+        self.kwargs.pop('entry_stop', None)
 
         # Conversions and parameters to be computed:
         alias = {'x': 'xp/10',  # converting "geant4" mm to "straxen" cm


### PR DESCRIPTION
The fix introduced in [PR#75](https://github.com/XENONnT/epix/pull/75) created some issues for **mc_chain** because we pass the actual G4 eventid to **wfsim** in order to add some offset to event times according to the specified rate. However, in **epix** this cut refers to _indices_ of G4 events, not to G4 eventids. Since `cut_by_eventid` was set to True in **epix** configuration, all simulations, except for the one where G4 eventid started at 0, had zero events in the **epix** output after [PR#75](https://github.com/XENONnT/epix/pull/75) had been propagated to `montecarlo-development`.

I did more thorough tests and updated `cut_by_eventid` treatment again, here's the test notebook:
/project2/lgrandi/pkavrigin/2024-01-21_test_epix/2024-01-21_TestEPIX.ipynb
In the notebook "expected" means the number of events from G4 file which we expect to see in the **epix** output with the given parameters, and "result" is what we actually get.

Output with the current **epix** master branch:
![2024-01-21_master](https://github.com/XENONnT/epix/assets/68543201/c1ca2ae5-35c3-4ca1-808f-22bac9bd9fe6)

Output with `fix_evtid_again` branch:
![2024-01-21_fix_evtid_again](https://github.com/XENONnT/epix/assets/68543201/c6d69a0c-6e83-484f-960a-9675fc5c9715)
